### PR TITLE
Automatically make log directory for nginx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN chown -R app log
 RUN chown -R app public
 RUN chown app Gemfile
 RUN chown app Gemfile.lock
+RUN mkdir -p /var/log/nginx/community.quran.com
 
 # cleanup apt
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
This prevents us from having to explicitly provide a directory to use for
log files.