### PR TITLE
Update Passenger Docker images to 0.9.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/passenger-customizable:0.9.19
+FROM phusion/passenger-customizable:0.9.24
 
 # set correct environment variables
 ENV HOME /root

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-ruby '2.3.1'
+ruby '2.3.3'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '>= 5.0.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -285,7 +285,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.3.1p112
+   ruby 2.3.3
 
 BUNDLED WITH
    1.13.7


### PR DESCRIPTION
This updates Phusion Passenger to 5.1.8, which has security fixes.